### PR TITLE
Updated AL-Go System Files

### DIFF
--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -2,6 +2,8 @@
 
 Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.
 
+## v2.4
+
 ### Issues
 - Issue [#171](https://github.com/microsoft/AL-Go/issues/171) create a workspace file when creating a project
 - Issue [#356](https://github.com/microsoft/AL-Go/issues/356) Publish to AppSource fails in multi project repo
@@ -24,7 +26,7 @@ This version contains a number of bug fixes to release branches, to ensure that 
 
 Recommended branching strategy:
 
-![Branching Strategy](Scenarios/images/branchingstrategy.png)
+![Branching Strategy](https://raw.githubusercontent.com/microsoft/AL-Go/main/Scenarios/images/branchingstrategy.png)
 
 ### New Settings
 New Project setting: EnableTaskScheduler in container executing tests and when setting up local development environment

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -2,11 +2,6 @@ name: ' CI/CD'
 
 on:
   workflow_dispatch:
-  workflow_call:
-  workflow_run:
-    workflows: ["Pull Request Handler"]
-    types:
-      - completed
   push:
     paths-ignore:
       - '**.md'
@@ -14,17 +9,13 @@ on:
       - '!.github/workflows/CICD.yaml'
     branches: [ 'main', 'release/*', 'feature/*' ]
 
-run-name: ${{ github.event_name != 'workflow_run' && 'CI/CD' || format('Check pull request from {1}/{2}{0} {3}',':',github.event.workflow_run.head_repository.owner.login,github.event.workflow_run.head_branch,github.event.workflow_run.display_title) }}
+defaults:
+  run:
+    shell: powershell
 
 permissions:
   contents: read
   actions: read
-  pull-requests: write
-  checks: write
-
-defaults:
-  run:
-    shell: powershell
 
 env:
   workflowDepth: 1
@@ -33,7 +24,6 @@ env:
 
 jobs:
   Initialization:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -52,100 +42,10 @@ jobs:
       buildOrderDepth: ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
       buildModes: ${{ steps.ReadSettings.outputs.BuildModes }}
     steps:
-      - name: Create CI/CD Workflow Check Run
-        id: CreateCheckRun
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var details_url = context.serverUrl.concat('/',context.repo.owner,'/',context.repo.repo,'/actions/runs/',context.runId)
-            var response = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'CI/CD Workflow',
-              head_sha: '${{ github.event.workflow_run.head_sha }}',
-              status: 'queued',
-              details_url: details_url,
-              output: {
-                title: 'CI/CD Workflow',
-                summary: '[Workflow Details]('.concat(details_url,')')
-              }
-            });
-            core.setOutput('checkRunId', response.data.id);
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
           lfs: true
-    
-      - name: Download Pull Request Changes
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            var run_id = Number('${{ github.event.workflow_run.id }}');
-            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: run_id
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == 'Pull_Request_Files'
-            })[0];
-            var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip'
-            });
-            var fs = require('fs');
-            fs.writeFileSync('.PullRequestChanges.zip', Buffer.from(download.data));
-
-      - name: Apply Pull Request Changes
-        if: github.event_name == 'workflow_run'
-        env:
-          PRREPOFULLNAME: ${{ github.event.workflow_run.head_repository.full_name }}
-        run: |
-          $ErrorActionPreference = "STOP"
-          Set-StrictMode -version 2.0
-          $location = (Get-Location).path
-          $prfolder = '.PullRequestChanges'
-          Expand-Archive -Path (Join-Path "." "$prfolder.zip") -DestinationPath (Join-Path "." $prfolder)
-          Remove-Item -Path (Join-Path "." "$prfolder.zip") -force
-          Get-ChildItem -Path $prfolder -Recurse -File | ForEach-Object {
-            $path = $_.FullName
-            $deleteFile = $path.EndsWith('.REMOVE')
-            if ($deleteFile) {
-              $path = $path.SubString(0,$path.Length-7)
-            }
-            $newPath = $path.Replace("$prfolder$([System.IO.Path]::DirectorySeparatorChar)","")
-            $newFolder = [System.IO.Path]::GetDirectoryName($newPath)
-            $extension = [System.IO.Path]::GetExtension($path)
-            $filename = [System.IO.Path]::GetFileName($path)
-            if ($ENV:PRREPOFULLNAME -ne $ENV:GITHUB_REPOSITORY) {
-              if ($extension -eq '.ps1' -or $extension -eq '.yaml' -or $extension -eq '.yml' -or $filename -eq "CODEOWNERS") {
-                throw "Pull Request containing changes to scripts, workflows or CODEOWNERS are not allowed from forks."
-              }
-            }
-            if ($deleteFile) {
-              if (Test-Path $newPath) {
-                Write-Host "Removing $newPath"
-                Remove-Item $newPath -Force
-              }
-              else {
-                Write-Host "$newPath was already deleted"
-              }
-            }
-            else {
-              if (-not (Test-Path $newFolder)) {
-                New-Item $newFolder -ItemType Directory | Out-Null
-              }
-              Write-Host "Copying $path to $newFolder"
-              Copy-Item $path -Destination $newFolder -Force
-            }
-          }
-          Remove-Item -Path $prfolder -recurse -force
 
       - name: Initialize the workflow
         id: init
@@ -286,7 +186,6 @@ jobs:
   CheckForUpdates:
     runs-on: [ windows-latest ]
     needs: [ Initialization ]
-    if: github.event_name != 'workflow_run'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -307,7 +206,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
+    if: needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:
@@ -325,54 +224,6 @@ jobs:
       BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
       BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
     steps:
-      - name: Create Build Job Check Run
-        id: CreateCheckRun
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var jobName = context.job.concat(' ${{ matrix.project }}')
-            var jobs = await github.rest.actions.listJobsForWorkflowRun({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.runId
-            });
-            var job = jobs.data.jobs.filter((job) => {
-              return job.name == jobName
-            })[0];
-            var details_url = context.serverUrl.concat('/',context.repo.owner,'/',context.repo.repo,'/actions/runs/',context.runId)
-            if (job) {
-              details_url = job.html_url;
-            }
-            var response = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: context.job.concat(' ${{ matrix.project }}'),
-              head_sha: '${{ github.event.workflow_run.head_sha }}',
-              status: 'in_progress',
-              details_url: details_url,
-              output: {
-                'title': context.job.concat(' ${{ matrix.project }}'),
-                'summary': '[Workflow Details]('.concat(details_url,')')
-              }
-            });
-            core.setOutput('checkRunId', response.data.id);
-            core.setOutput('detailsUrl', details_url);
-
-      - name: Update CI/CD Workflow Check Run
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var response = await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: ${{ needs.Initialization.outputs.checkRunId }},
-              status: 'in_progress'
-            });
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -383,74 +234,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: '.dependencies'
-
-      - name: Download Pull Request Changes
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            var run_id = Number('${{ github.event.workflow_run.id }}');
-            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: run_id
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == 'Pull_Request_Files'
-            })[0];
-            var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip'
-            });
-            var fs = require('fs');
-            fs.writeFileSync('.PullRequestChanges.zip', Buffer.from(download.data));
-
-      - name: Apply Pull Request Changes
-        if: github.event_name == 'workflow_run'
-        env:
-          PRREPOFULLNAME: ${{ github.event.workflow_run.head_repository.full_name }}
-        run: |
-          $ErrorActionPreference = "STOP"
-          Set-StrictMode -version 2.0
-          $location = (Get-Location).path
-          $prfolder = '.PullRequestChanges'
-          Expand-Archive -Path (Join-Path "." "$prfolder.zip") -DestinationPath (Join-Path "." $prfolder)
-          Remove-Item -Path (Join-Path "." "$prfolder.zip") -force
-          Get-ChildItem -Path $prfolder -Recurse -File | ForEach-Object {
-            $path = $_.FullName
-            $deleteFile = $path.EndsWith('.REMOVE')
-            if ($deleteFile) {
-              $path = $path.SubString(0,$path.Length-7)
-            }
-            $newPath = $path.Replace("$prfolder$([System.IO.Path]::DirectorySeparatorChar)","")
-            $newFolder = [System.IO.Path]::GetDirectoryName($newPath)
-            $extension = [System.IO.Path]::GetExtension($path)
-            $filename = [System.IO.Path]::GetFileName($path)
-            if ($ENV:PRREPOFULLNAME -ne $ENV:GITHUB_REPOSITORY) {
-              if ($extension -eq '.ps1' -or $extension -eq '.yaml' -or $extension -eq '.yml' -or $filename -eq "CODEOWNERS") {
-                throw "Pull Request containing changes to scripts, workflows or CODEOWNERS are not allowed from forks."
-              }
-            }
-            if ($deleteFile) {
-              if (Test-Path $newPath) {
-                Write-Host "Removing $newPath"
-                Remove-Item $newPath -Force
-              }
-              else {
-                Write-Host "$newPath was already deleted"
-              }
-            }
-            else {
-              if (-not (Test-Path $newFolder)) {
-                New-Item $newFolder -ItemType Directory | Out-Null
-              }
-              Write-Host "Copying $path to $newFolder"
-              Copy-Item $path -Destination $newFolder -Force
-            }
-          }
-          Remove-Item -Path $prfolder -recurse -force
 
       - name: Read settings
         uses: freddydk/AL-Go-Actions/ReadSettings@authflow
@@ -484,32 +267,14 @@ jobs:
           buildMode: ${{ matrix.buildMode }}
 
       - name: Calculate Artifact names
-        id: calculateArtifactNames
+        uses: freddydk/AL-Go-Actions/CalculateArtifactNames@authflow
         if: success() || failure()
-        run: |
-          $ErrorActionPreference = "STOP"
-          Set-StrictMode -version 2.0
-          $settings = '${{ env.Settings }}' | ConvertFrom-Json
-          $project = '${{ matrix.project }}'
-          $buildMode = '${{ matrix.buildMode }}'
-          if ("$ENV:GITHUB_EVENT_NAME" -eq 'workflow_run') {
-            $eventStr = Get-Content $ENV:GITHUB_EVENT_PATH -Encoding UTF8
-            $event = $eventStr | ConvertFrom-Json
-            $ref = "PR$($event.workflow_run.id)"
-          }
-          else {
-            $ref = "$ENV:GITHUB_REF_NAME".Replace('/','_')
-          }
-          if ($project -eq ".") { $project = $settings.repoName }
-          if ($buildMode -eq 'Default') { $buildMode = '' }
-          'Apps','Dependencies','TestApps','TestResults','BcptTestResults','BuildOutput','ContainerEventLog' | ForEach-Object {
-            $name = "$($_)ArtifactsName"
-            $value = "$($project.Replace('\','_').Replace('/','_'))-$($ref)-$buildMode$_-$($settings.repoVersion).$($settings.appBuild).$($settings.appRevision)"
-            Add-Content -Path $env:GITHUB_OUTPUT -Value "$name=$value"
-            Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
-          }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "BuildMode=$buildMode"
-          Add-Content -Path $env:GITHUB_ENV -Value "BuildMode=$buildMode"
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          settingsJson: ${{ env.Settings }}
+          project: ${{ matrix.project }}
+          buildMode: ${{ matrix.buildMode }}
+          branchName: ${{ github.ref_name }}
 
       - name: Upload thisbuild artifacts - apps
         if: env.workflowDepth > 1
@@ -594,28 +359,6 @@ jobs:
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           Project: ${{ matrix.project }}
 
-      - name: Update Build Job Check Run
-        if: always() && github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        env:
-          TestResultMD: ${{ steps.analyzeTestResults.outputs.TestResultMD }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var details_url = '${{ steps.CreateCheckRun.outputs.detailsUrl }}'
-            var testResultMD = process.env.TestResultMD
-            var response = await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: ${{ steps.CreateCheckRun.outputs.checkRunId }},
-              conclusion: '${{ steps.RunPipeline.conclusion }}',
-              output: {
-                title: context.job.concat(' ${{ matrix.project }}'),
-                summary: testResultMD.replaceAll('\\n','\n'),
-                text: '[Workflow details]('.concat(details_url,')')
-              }
-            });
-
       - name: Cleanup
         if: always()
         uses: freddydk/AL-Go-Actions/PipelineCleanup@authflow
@@ -626,7 +369,7 @@ jobs:
 
   Deploy:
     needs: [ Initialization, Build ]
-    if: always() && needs.Build.result == 'Success' && github.event_name != 'workflow_run' && needs.Initialization.outputs.environmentCount > 0
+    if: always() && needs.Build.result == 'Success' && needs.Initialization.outputs.environmentCount > 0
     strategy: ${{ fromJson(needs.Initialization.outputs.environments) }}
     runs-on: ${{ fromJson(matrix.os) }}
     name: Deploy to ${{ matrix.environment }}
@@ -750,7 +493,7 @@ jobs:
 
   Deliver:
     needs: [ Initialization, Build ]
-    if: always() && needs.Build.result == 'Success' && github.event_name != 'workflow_run' && needs.Initialization.outputs.deliveryTargetCount > 0
+    if: always() && needs.Build.result == 'Success' && needs.Initialization.outputs.deliveryTargetCount > 0
     strategy:
       matrix:
         deliveryTarget: ${{ fromJson(needs.Initialization.outputs.deliveryTargets) }}
@@ -801,25 +544,8 @@ jobs:
           deliveryTarget: ${{ matrix.deliveryTarget }}
           artifacts: '.artifacts'
 
-  UpdatePRcheck:
-    if: always() && github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
-    runs-on: [ windows-latest ]
-    needs: [ Initialization, Build ]
-    steps:
-      - name: Update CI/CD Workflow Check Run
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var response = await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: ${{ needs.Initialization.outputs.checkRunId }},
-              conclusion: '${{ needs.Build.result }}'
-            });
-
   PostProcess:
-    if: (!cancelled()) && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    if: (!cancelled())
     runs-on: [ windows-latest ]
     needs: [ Initialization, Build, Deploy, Deliver ]
     steps:

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -1,4 +1,4 @@
-name: 'Pull Request Handler'
+name: 'Pull Request Build'
 
 on:
   pull_request_target:
@@ -15,8 +15,14 @@ permissions:
   actions: read
   pull-requests: read
 
+env:
+  workflowDepth: 1
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+
 jobs:
-  PullRequestHandler:
+  PregateCheck:
+    if: github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name
     runs-on: [ windows-latest ]
     steps:
       - uses: actions/checkout@v3
@@ -24,66 +30,223 @@ jobs:
           lfs: true
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Determine Changed Files
-        id: ChangedFiles
+      - uses: freddydk/AL-Go-Actions/VerifyPRChanges@authflow
+        with:
+          baseSHA: ${{ github.event.pull_request.base.sha }}
+          headSHA: ${{ github.event.pull_request.head.sha }}
+          prbaseRepository: ${{ github.event.pull_request.base.repo.full_name }}
+
+  Initialization:
+    needs: [ PregateCheck ]
+    if: (!failure())
+    runs-on: [ windows-latest ]
+    outputs:
+      telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+      settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
+      projects: ${{ steps.ReadSettings.outputs.ProjectsJson }}
+      projectCount: ${{ steps.ReadSettings.outputs.ProjectCount }}
+      githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
+      githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
+      projectDependenciesJson: ${{ steps.ReadSettings.outputs.ProjectDependenciesJson }}
+      buildOrderJson: ${{ steps.ReadSettings.outputs.BuildOrderJson }}
+      buildOrderDepth: ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
+      buildModes: ${{ steps.ReadSettings.outputs.BuildModes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Initialize the workflow
+        id: init
+        uses: freddydk/AL-Go-Actions/WorkflowInitialize@authflow
+        with:
+          shell: powershell
+          eventId: "DO0104"
+
+      - name: Read settings
+        id: ReadSettings
+        uses: freddydk/AL-Go-Actions/ReadSettings@authflow
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          getProjects: 'Y'
+          getEnvironments: '*'
+      
+      - name: Determine Build Order
+        if: env.workflowDepth > 1
+        id: BuildOrder
         run: |
           $ErrorActionPreference = "STOP"
           Set-StrictMode -version 2.0
-          $sb = [System.Text.StringBuilder]::new()
-          $headers = @{             
-              "Authorization" = 'token ${{ secrets.GITHUB_TOKEN }}'
-              "Accept" = "application/vnd.github.baptiste-preview+json"
+          $projects = '${{ steps.ReadSettings.outputs.ProjectsJson }}' | ConvertFrom-Json
+          $buildOrder = '${{ steps.ReadSettings.outputs.BuildOrderJson }}' | ConvertFrom-Json
+          $depth = ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
+          $workflowDepth = ${{ env.workflowDepth }}
+          if ($depth -lt $workflowDepth) {
+            Write-Host "::Error::Project Dependencies depth is $depth. Workflow is only setup for $workflowDepth. You need to Run Update AL-Go System Files to update the workflows"
+            $host.SetShouldExit(1)
           }
-          $baseSHA = '${{ github.event.pull_request.base.sha }}'
-          $headSHA = '${{ github.event.pull_request.head.sha }}'
-          $url = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/compare/$baseSHA...$headSHA"
-          $response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri $url | ConvertFrom-Json
-          $location = (Get-Location).path
-          $prfolder = [GUID]::NewGuid().ToString()
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "prfolder=$prfolder"
-          $prPath = Join-Path $location $prFolder
-          New-Item -Path $prPath -ItemType Directory | Out-Null
-          $prfilesChanged = @()
-          Write-Host "Files Changed:"
-          $response.files | ForEach-Object {
-            $filename = $_.filename
-            $status = $_.status
-            Write-Host "- $filename $status"
-            $prFilesChanged += $filename
-            $path = Join-Path $location $filename
-            $newPath = Join-Path $prPath $filename
-            $newfolder = [System.IO.Path]::GetDirectoryName($newpath)
-            $extension = [System.IO.Path]::GetExtension($path)
-            $name = [System.IO.Path]::GetFileName($path)
-            if ('${{ github.event.pull_request.head.repo.full_name }}' -ne $ENV:GITHUB_REPOSITORY) {
-              if ($extension -eq '.ps1' -or $extension -eq '.yaml' -or $extension -eq '.yml' -or $name -eq "CODEOWNERS") {
-                throw "Pull Request containing changes to scripts, workflows or CODEOWNERS are not allowed from forks."
-              }
-            }
-            if (-not (Test-Path $newfolder)) {
-              New-Item $newfolder -ItemType Directory | Out-Null
-            }
-            if ($status -eq "renamed") {
-              Copy-Item -Path $path -Destination $newfolder -Force
-              $oldPath = Join-Path $prPath $_.previous_filename
-              $oldFolder = [System.IO.Path]::GetDirectoryName($oldpath)
-              if (-not (Test-Path $oldFolder)) {
-                New-Item $oldFolder -ItemType Directory | Out-Null
-              }
-              New-Item -Path "$oldPath.REMOVE" -itemType File | Out-Null
-            }
-            elseif ($status -eq "removed") {
-              New-Item -Path $newfolder -name "$name.REMOVE" -itemType File | Out-Null
+          $step = $depth
+          $depth..1 | ForEach-Object {
+            $ps = @($buildOrder."$_" | Where-Object { $projects -contains $_ })
+            if ($ps.Count -eq 1) {
+              $projectsJSon = "[$($ps | ConvertTo-Json -compress)]"
             }
             else {
-              Copy-Item -Path $path -Destination $newfolder -Force
+              $projectsJSon = $ps | ConvertTo-Json -compress
+            }
+            if ($ps.Count -gt 0) {
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "projects$($step)Json=$projectsJson"
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "projects$($step)Count=$($ps.count)"
+              Write-Host "projects$($step)Json=$projectsJson"
+              Write-Host "projects$($step)Count=$($ps.count)"
+              $step--
             }
           }
-          Set-Content -path (Join-Path $prPath ".PullRequestCommentId") -value '${{ steps.CreateComment.outputs.comment_id }}' -Encoding UTF8 -NoNewLine -Force
-          Set-Content -path (Join-Path $prPath ".PullRequestFilesChanged") -value $prFilesChanged -Encoding UTF8 -Force
+          while ($step -ge 1) {
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "projects$($step)Json="
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "projects$($step)Count=0"
+              Write-Host "projects$($step)Json="
+              Write-Host "projects$($step)Count=0"
+              $step--
+          }
 
-      - name: Upload Changed Files
+  Build:
+    needs: [ Initialization ]
+    if: (!failure()) && needs.Initialization.outputs.projectCount > 0
+    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
+    defaults:
+      run:
+        shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+    strategy:
+      matrix:
+        project: ${{ fromJson(needs.Initialization.outputs.projects) }}
+        buildMode: ${{ fromJson(needs.Initialization.outputs.buildModes) }}
+      fail-fast: false
+    name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
+    outputs:
+      AppsArtifactsName: ${{ steps.calculateArtifactNames.outputs.AppsArtifactsName }}
+      TestAppsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestAppsArtifactsName }}
+      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
+      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
+      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+    
+      - name: Download thisbuild artifacts
+        if: env.workflowDepth > 1
+        uses: actions/download-artifact@v3
+        with:
+          path: '.dependencies'
+
+      - name: Read settings
+        uses: freddydk/AL-Go-Actions/ReadSettings@authflow
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
+
+      - name: Read secrets
+        uses: freddydk/AL-Go-Actions/ReadSecrets@authflow
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'licenseFileUrl,insiderSasToken,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId'
+
+      - name: Run pipeline
+        id: RunPipeline
+        uses: freddydk/AL-Go-Actions/RunPipeline@authflow
+        env:
+          BuildMode: ${{ matrix.buildMode }}
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          Project: ${{ matrix.project }}
+          ProjectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+          settingsJson: ${{ env.Settings }}
+          SecretsJson: ${{ env.RepoSecrets }}
+          buildMode: ${{ matrix.buildMode }}
+
+      - name: Calculate Artifact names
+        uses: freddydk/AL-Go-Actions/CalculateArtifactNames@authflow
+        if: success() || failure()
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          settingsJson: ${{ env.Settings }}
+          project: ${{ matrix.project }}
+          buildMode: ${{ matrix.buildMode }}
+          branchName: ${{ github.ref_name }}
+
+      - name: Upload thisbuild artifacts - apps
+        if: env.workflowDepth > 1
         uses: actions/upload-artifact@v3
         with:
-          name: Pull_Request_Files
-          path: '${{ steps.ChangedFiles.outputs.prfolder }}/'
+          name: 'thisbuild-${{ matrix.project }}-${{ env.BuildMode }}Apps'
+          path: '${{ matrix.project }}/.buildartifacts/Apps/'
+          if-no-files-found: ignore
+          retention-days: 1
+
+      - name: Upload thisbuild artifacts - test apps
+        if: env.workflowDepth > 1
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'thisbuild-${{ matrix.project }}-${{ env.BuildMode }}TestApps'
+          path: '${{ matrix.project }}/.buildartifacts/TestApps/'
+          if-no-files-found: ignore
+          retention-days: 1
+
+      - name: Publish artifacts - test results
+        uses: actions/upload-artifact@v3
+        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
+        with:
+          name: ${{ env.TestResultsArtifactsName }}
+          path: '${{ matrix.project }}/TestResults.xml'
+          if-no-files-found: ignore
+
+      - name: Publish artifacts - bcpt test results
+        uses: actions/upload-artifact@v3
+        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
+        with:
+          name: ${{ env.BcptTestResultsArtifactsName }}
+          path: '${{ matrix.project }}/bcptTestResults.json'
+          if-no-files-found: ignore
+
+      - name: Analyze Test Results
+        id: analyzeTestResults
+        if: success() || failure()
+        uses: freddydk/AL-Go-Actions/AnalyzeTests@authflow
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          Project: ${{ matrix.project }}
+
+      - name: Cleanup
+        if: always()
+        uses: freddydk/AL-Go-Actions/PipelineCleanup@authflow
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          Project: ${{ matrix.project }}
+
+  PostProcess:
+    runs-on: [ windows-latest ]
+    needs: [ Initialization, Build ]
+    if: (!cancelled())
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Finalize the workflow
+        id: PostProcess
+        uses: freddydk/AL-Go-Actions/WorkflowPostProcess@authflow
+        with:
+          shell: powershell
+          eventId: "DO0104"
+          telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}


### PR DESCRIPTION
## Preview

Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.

## v2.4

### Issues
- Issue [#171](https://github.com/microsoft/AL-Go/issues/171) create a workspace file when creating a project
- Issue [#356](https://github.com/microsoft/AL-Go/issues/356) Publish to AppSource fails in multi project repo
- Issue [#358](https://github.com/microsoft/AL-Go/issues/358) Publish To Environment Action stopped working in v2.3
- Issue [#362](https://github.com/microsoft/AL-Go/issues/362) Support for EnableTaskScheduler
- Issue [#360](https://github.com/microsoft/AL-Go/issues/360) Creating a release and deploying from a release branch
- Issue [#371](https://github.com/microsoft/AL-Go/issues/371) 'No previous release found' for builds on release branches
- Issue [#376](https://github.com/microsoft/AL-Go/issues/376) CICD jobs that are triggered by the pull request trigger run directly to an error if title contains quotes

### Release Branches
**NOTE:** Release Branches are now only named after major.minor if the patch value is 0 in the release tag (which must be semver compatible)

This version contains a number of bug fixes to release branches, to ensure that the recommended branching strategy is fully supported. Bugs fixed includes:
- Release branches was named after the full tag (1.0.0), even though subsequent hotfixes released from this branch would be 1.0.x
- Release branches named 1.0 wasn't picked up as a release branch
- Release notes contained the wrong changelog
- The previous release was always set to be the first release from a release branch
- SemVerStr could not have 5 segments after the dash
- Release was created on the right SHA, but the release branch was created on the wrong SHA

Recommended branching strategy:

![Branching Strategy](https://raw.githubusercontent.com/microsoft/AL-Go/main/Scenarios/images/branchingstrategy.png)

### New Settings
New Project setting: EnableTaskScheduler in container executing tests and when setting up local development environment

### Support for GitHub variables: ALGoOrgSettings and ALGoRepoSettings
Recently, GitHub added support for variables, which you can define on your organization or your repository.
AL-Go now supports that you can define a GitHub variable called ALGoOrgSettings, which will work for all repositories (with access to the variable)
Org Settings will be applied before Repo settings and local repository settings files will override values in the org settings
You can also define a variable called ALGoRepoSettings on the repository, which will be applied after reading the Repo Settings file in the repo
Example for usage could be setup of branching strategies, versioning or an appDependencyProbingPaths to repositories which all repositories share.
appDependencyProbingPaths from settings variables are merged together with appDependencyProbingPaths defined in repositories

### Refactoring and tests
ReadSettings has been refactored to allow organization wide settings to be added as well. CI Tests have been added to cover ReadSettings.
